### PR TITLE
implemented refresh token rotations and storage in Redis. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,17 @@ services:
       - ./services/raum/src/main/resources/init.sql:/init.sql
     entrypoint: ["sh", "-c", "psql -h raum-postgres -U postgres -d raum -f /init.sql"]
 
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   operational-postgres:
     image: postgres:18.1-alpine3.23
     container_name: operational-postgres
@@ -161,9 +172,13 @@ services:
     depends_on:
       kenoma-pre-init:
         condition: service_completed_successfully
+      redis:
+        condition: service_healthy
     environment:
       RAUM_BASE_URL: http://raum:8080
       OPENBAO_BASE_URL: http://openbao:8200
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       MAILGUN_API_KEY: ${MAILGUN_API_KEY}
       MAILGUN_DOMAIN: ${MAILGUN_DOMAIN}
       MAILGUN_FROM: ${MAILGUN_FROM:-}

--- a/services/vassago/pom.xml
+++ b/services/vassago/pom.xml
@@ -134,5 +134,9 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/services/vassago/src/main/java/vassago/config/SecurityConfig.java
+++ b/services/vassago/src/main/java/vassago/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
         return http
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .authorizeExchange(exchanges -> exchanges
-                        .pathMatchers("/auth/login", "/auth/recover", "/user/verify").permitAll()
+                        .pathMatchers("/auth/login", "/auth/refresh", "/auth/recover", "/user/verify").permitAll()
                         .anyExchange().authenticated()
                 )
                 .exceptionHandling(e -> e

--- a/services/vassago/src/main/java/vassago/config/VassagoConfig.java
+++ b/services/vassago/src/main/java/vassago/config/VassagoConfig.java
@@ -3,12 +3,20 @@ package vassago.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import java.util.UUID;
 
 @Configuration
 public class VassagoConfig {
+
     @Bean
     public UUID serviceId(@Value("${vassago.service-id}") String serviceId) {
         return UUID.fromString(serviceId);
+    }
+
+    @Bean
+    public ReactiveStringRedisTemplate reactiveStringRedisTemplate(ReactiveRedisConnectionFactory factory) {
+        return new ReactiveStringRedisTemplate(factory);
     }
 }

--- a/services/vassago/src/main/java/vassago/controllers/AuthController.java
+++ b/services/vassago/src/main/java/vassago/controllers/AuthController.java
@@ -3,6 +3,7 @@ package vassago.controllers;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import vassago.dto.LoginRequestDTO;
 import vassago.dto.LoginResponseDTO;
@@ -17,8 +18,19 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public Mono<LoginResponseDTO> login(@RequestBody LoginRequestDTO dto) {
-        return authService.login(dto).map(LoginResponseDTO::new);
+    public Mono<LoginResponseDTO> login(@RequestBody LoginRequestDTO dto, ServerWebExchange exchange) {
+        return authService.login(dto, exchange.getResponse()).map(LoginResponseDTO::new);
+    }
+
+    @PostMapping("/refresh")
+    public Mono<LoginResponseDTO> refresh(ServerWebExchange exchange) {
+        return authService.refresh(exchange).map(LoginResponseDTO::new);
+    }
+
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> logout(ServerWebExchange exchange) {
+        return authService.logout(exchange);
     }
 
     @PostMapping("/recover")

--- a/services/vassago/src/main/java/vassago/security/JwtAuthFilter.java
+++ b/services/vassago/src/main/java/vassago/security/JwtAuthFilter.java
@@ -10,6 +10,8 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
+
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -19,6 +21,7 @@ import java.util.UUID;
 public class JwtAuthFilter implements WebFilter {
     private static final String BEARER_PREFIX = "Bearer ";
     private final JwtService jwtService;
+    private final RedisTokenService redisTokenService;
     private final UUID serviceId;
 
     @Override
@@ -30,14 +33,24 @@ public class JwtAuthFilter implements WebFilter {
         String token = authHeader.substring(BEARER_PREFIX.length());
         return jwtService.validateToken(token)
                 .flatMap(claims -> {
-                    String username = claims.getSubject();
-                    UUID orgId = UUID.fromString(claims.get("orgId", String.class));
-                    @SuppressWarnings("unchecked")
-                    Map<String, List<String>> roles = RolesUtils.deserialize(
-                            claims.get("roles", String.class));
-                    VassagoAuthentication auth = new VassagoAuthentication(orgId, username, roles, serviceId);
-                    return chain.filter(exchange)
-                            .contextWrite(ReactiveSecurityContextHolder.withAuthentication(auth));
+                    String jti = claims.getId();
+                    return redisTokenService.isBlacklisted(jti)
+                            .onErrorReturn(false)
+                            .flatMap(blacklisted -> {
+                                if (blacklisted) {
+                                    exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                                    return exchange.getResponse().setComplete();
+                                }
+                                String username = claims.getSubject();
+                                UUID orgId = UUID.fromString(claims.get("orgId", String.class));
+                                Instant expiry = claims.getExpiration().toInstant();
+                                Map<String, List<String>> roles = RolesUtils.deserialize(
+                                        claims.get("roles", String.class));
+                                VassagoAuthentication auth = new VassagoAuthentication(
+                                        orgId, username, roles, serviceId, jti, expiry);
+                                return chain.filter(exchange)
+                                        .contextWrite(ReactiveSecurityContextHolder.withAuthentication(auth));
+                            });
                 })
                 .onErrorResume(e -> {
                     if (e instanceof org.springframework.web.server.ResponseStatusException) {

--- a/services/vassago/src/main/java/vassago/security/JwtService.java
+++ b/services/vassago/src/main/java/vassago/security/JwtService.java
@@ -31,7 +31,7 @@ public class JwtService {
             @Value("${openbao.base-url}") String openBaoBaseUrl,
             @Value("${vassago.openbao.token}") String openBaoToken,
             @Value("${vassago.jwt.transit-key-name}") String transitKeyName,
-            @Value("${vassago.jwt.ttl-seconds:3600}") long ttlSeconds) {
+            @Value("${vassago.jwt.ttl-seconds:300}") long ttlSeconds) {
         this.openBaoClient = WebClient.builder()
                 .baseUrl(openBaoBaseUrl)
                 .defaultHeader("X-Vault-Token", openBaoToken)
@@ -83,6 +83,10 @@ public class JwtService {
         return jwtValidator.getPublicKey();
     }
 
+    public long remainingSeconds(Instant expiry) {
+        return Math.max(0, expiry.getEpochSecond() - Instant.now().getEpochSecond());
+    }
+
     private String buildClaimsJson(UUID orgId, String username, Map<String, List<String>> roles,
                                    Instant now, Instant exp) {
         try {
@@ -92,7 +96,8 @@ public class JwtService {
                     "orgId", orgId.toString(),
                     "roles", rolesJson,
                     "iat", now.getEpochSecond(),
-                    "exp", exp.getEpochSecond()
+                    "exp", exp.getEpochSecond(),
+                    "jti", UUID.randomUUID().toString()
             );
             return OBJECT_MAPPER.writeValueAsString(claims);
         } catch (Exception e) {

--- a/services/vassago/src/main/java/vassago/security/RedisTokenService.java
+++ b/services/vassago/src/main/java/vassago/security/RedisTokenService.java
@@ -1,0 +1,83 @@
+package vassago.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class RedisTokenService {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String REFRESH_PREFIX = "refresh:";
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+
+    private final ReactiveStringRedisTemplate redis;
+    private final long refreshTtlSeconds;
+
+    public RedisTokenService(ReactiveStringRedisTemplate redis,
+                             @Value("${vassago.refresh-token.ttl-seconds:2592000}") long refreshTtlSeconds) {
+        this.redis = redis;
+        this.refreshTtlSeconds = refreshTtlSeconds;
+    }
+
+    public Mono<Void> storeRefreshToken(String tokenHash, UUID orgId, String username, String fpHash) {
+        String value = serialize(orgId, username, fpHash);
+        return redis.opsForValue()
+                .set(REFRESH_PREFIX + tokenHash, value, Duration.ofSeconds(refreshTtlSeconds))
+                .then();
+    }
+
+    public Mono<RefreshTokenData> lookupRefreshToken(String tokenHash) {
+        return redis.opsForValue()
+                .get(REFRESH_PREFIX + tokenHash)
+                .mapNotNull(this::deserialize);
+    }
+
+    public Mono<Void> deleteRefreshToken(String tokenHash) {
+        return redis.delete(REFRESH_PREFIX + tokenHash).then();
+    }
+
+    public Mono<Void> blacklistJwt(String jti, long remainingSeconds) {
+        return redis.opsForValue()
+                .set(BLACKLIST_PREFIX + jti, "1", Duration.ofSeconds(remainingSeconds))
+                .then();
+    }
+
+    public Mono<Boolean> isBlacklisted(String jti) {
+        return redis.hasKey(BLACKLIST_PREFIX + jti);
+    }
+
+    private String serialize(UUID orgId, String username, String fpHash) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(Map.of(
+                    "orgId", orgId.toString(),
+                    "username", username,
+                    "fpHash", fpHash
+            ));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize refresh token entry", e);
+        }
+    }
+
+    private RefreshTokenData deserialize(String json) {
+        try {
+            JsonNode node = OBJECT_MAPPER.readTree(json);
+            return new RefreshTokenData(
+                    UUID.fromString(node.get("orgId").asText()),
+                    node.get("username").asText(),
+                    node.get("fpHash").asText()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to deserialize refresh token entry", e);
+        }
+    }
+
+    public record RefreshTokenData(UUID orgId, String username, String fpHash) {}
+}

--- a/services/vassago/src/main/java/vassago/security/VassagoAuthentication.java
+++ b/services/vassago/src/main/java/vassago/security/VassagoAuthentication.java
@@ -1,8 +1,10 @@
 package vassago.security;
 
+import lombok.Getter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -12,21 +14,27 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class VassagoAuthentication implements Authentication {
+    @Getter
     private final UUID orgId;
     private final String username;
+    @Getter
     private final Map<String, List<String>> roles;
     private final UUID serviceId;
+    @Getter
+    private final String jti;
+    @Getter
+    private final Instant expiry;
     private boolean authenticated = true;
 
-    public VassagoAuthentication(UUID orgId, String username, Map<String, List<String>> roles, UUID serviceId) {
+    public VassagoAuthentication(UUID orgId, String username, Map<String, List<String>> roles,
+                                 UUID serviceId, String jti, Instant expiry) {
         this.orgId     = orgId;
         this.username  = username;
         this.roles     = roles;
         this.serviceId = serviceId;
+        this.jti       = jti;
+        this.expiry    = expiry;
     }
-
-    public UUID getOrgId()                      { return orgId; }
-    public Map<String, List<String>> getRoles() { return roles; }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/services/vassago/src/main/java/vassago/services/AuthService.java
+++ b/services/vassago/src/main/java/vassago/services/AuthService.java
@@ -1,21 +1,30 @@
 package vassago.services;
 
-import common.utils.RolesUtils;
-import lombok.RequiredArgsConstructor;
 import common.exception.NotFoundException;
 import common.exception.UnauthorizedException;
+import common.utils.RolesUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import vassago.db.VassagoDbService;
 import vassago.dto.LoginRequestDTO;
 import vassago.dto.RecoverRequestDTO;
 import vassago.security.JwtService;
+import vassago.security.RedisTokenService;
+import vassago.security.VassagoAuthentication;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -28,13 +37,19 @@ import java.util.UUID;
 public class AuthService {
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String REFRESH_COOKIE = "session-rt";
+    private static final String FP_COOKIE = "session-fp";
 
     private final VassagoDbService vassagoDbService;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final MailgunService mailgunService;
+    private final RedisTokenService redisTokenService;
 
-    public Mono<String> login(LoginRequestDTO dto) {
+    @Value("${vassago.refresh-token.ttl-seconds:2592000}")
+    private long refreshTtlSeconds;
+
+    public Mono<String> login(LoginRequestDTO dto, ServerHttpResponse response) {
         return vassagoDbService.getClient(dto.getOrgId())
                 .onErrorMap(NotFoundException.class, ex -> new UnauthorizedException("Invalid credentials"))
                 .flatMap(client -> client.sql("""
@@ -45,8 +60,7 @@ public class AuthService {
                         .bind("username", dto.getUsername())
                         .fetch()
                         .one()
-                        .switchIfEmpty(Mono.error(
-                                new UnauthorizedException("Invalid credentials")))
+                        .switchIfEmpty(Mono.error(new UnauthorizedException("Invalid credentials")))
                 )
                 .flatMap(row -> {
                     String storedHash = (String) row.get("password");
@@ -54,7 +68,80 @@ public class AuthService {
                         return Mono.error(new UnauthorizedException("Invalid credentials"));
                     }
                     Map<String, List<String>> roles = RolesUtils.deserialize((String) row.get("roles"));
-                    return jwtService.issueToken(dto.getOrgId(), dto.getUsername(), roles);
+                    return jwtService.issueToken(dto.getOrgId(), dto.getUsername(), roles)
+                            .flatMap(token -> {
+                                String rtRaw = generateToken();
+                                String rtHash = hashToken(rtRaw);
+                                String fpRaw = generateToken();
+                                String fpHash = hashToken(fpRaw);
+                                return redisTokenService.storeRefreshToken(rtHash, dto.getOrgId(), dto.getUsername(), fpHash)
+                                        .then(Mono.fromRunnable(() -> {
+                                            setCookie(response, REFRESH_COOKIE, rtRaw);
+                                            setCookie(response, FP_COOKIE, fpRaw);
+                                        }))
+                                        .thenReturn(token);
+                            });
+                });
+    }
+
+    public Mono<String> refresh(ServerWebExchange exchange) {
+        HttpCookie rtCookie = exchange.getRequest().getCookies().getFirst(REFRESH_COOKIE);
+        if (rtCookie == null) {
+            return Mono.error(new UnauthorizedException("No session"));
+        }
+        String rtHash = hashToken(rtCookie.getValue());
+        return redisTokenService.lookupRefreshToken(rtHash)
+                .switchIfEmpty(Mono.error(new UnauthorizedException("Invalid or expired session")))
+                .flatMap(data -> {
+                    HttpCookie fpCookie = exchange.getRequest().getCookies().getFirst(FP_COOKIE);
+                    if (fpCookie == null || !hashToken(fpCookie.getValue()).equals(data.fpHash())) {
+                        return redisTokenService.deleteRefreshToken(rtHash)
+                                .then(Mono.error(new UnauthorizedException("Session binding mismatch")));
+                    }
+                    return vassagoDbService.getClient(data.orgId())
+                            .flatMap(client -> client.sql("""
+                                    SELECT roles FROM users
+                                    WHERE username = :username AND stopped_at IS NULL AND is_ready
+                                    """)
+                                    .bind("username", data.username())
+                                    .fetch()
+                                    .one()
+                                    .switchIfEmpty(Mono.error(new UnauthorizedException("Invalid or expired session")))
+                            )
+                            .flatMap(row -> {
+                                Map<String, List<String>> roles = RolesUtils.deserialize((String) row.get("roles"));
+                                return jwtService.issueToken(data.orgId(), data.username(), roles);
+                            })
+                            .flatMap(token -> {
+                                String newRtRaw = generateToken();
+                                String newRtHash = hashToken(newRtRaw);
+                                String newFpRaw = generateToken();
+                                String newFpHash = hashToken(newFpRaw);
+                                return redisTokenService.deleteRefreshToken(rtHash)
+                                        .then(redisTokenService.storeRefreshToken(newRtHash, data.orgId(), data.username(), newFpHash))
+                                        .then(Mono.fromRunnable(() -> {
+                                            setCookie(exchange.getResponse(), REFRESH_COOKIE, newRtRaw);
+                                            setCookie(exchange.getResponse(), FP_COOKIE, newFpRaw);
+                                        }))
+                                        .thenReturn(token);
+                            });
+                });
+    }
+
+    public Mono<Void> logout(ServerWebExchange exchange) {
+        return ReactiveSecurityContextHolder.getContext()
+                .mapNotNull(ctx -> (VassagoAuthentication) ctx.getAuthentication())
+                .flatMap(auth -> {
+                    long remainingSeconds = jwtService.remainingSeconds(auth.getExpiry());
+                    HttpCookie rtCookie = exchange.getRequest().getCookies().getFirst(REFRESH_COOKIE);
+                    Mono<Void> blacklistMono = remainingSeconds > 0
+                            ? redisTokenService.blacklistJwt(auth.getJti(), remainingSeconds)
+                            : Mono.empty();
+                    Mono<Void> deleteMono = rtCookie != null
+                            ? redisTokenService.deleteRefreshToken(hashToken(rtCookie.getValue()))
+                            : Mono.empty();
+                    clearCookies(exchange.getResponse());
+                    return blacklistMono.then(deleteMono);
                 });
     }
 
@@ -87,6 +174,28 @@ public class AuthService {
                         })
                 )
                 .then();
+    }
+
+    private void setCookie(ServerHttpResponse response, String name, String value) {
+        response.addCookie(ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .maxAge(Duration.ofSeconds(refreshTtlSeconds))
+                .path("/auth")
+                .build());
+    }
+
+    private void clearCookies(ServerHttpResponse response) {
+        for (String name : new String[]{REFRESH_COOKIE, FP_COOKIE}) {
+            response.addCookie(ResponseCookie.from(name, "")
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("Strict")
+                    .maxAge(Duration.ZERO)
+                    .path("/auth")
+                    .build());
+        }
     }
 
     private static String generateToken() {

--- a/services/vassago/src/main/resources/application.yaml
+++ b/services/vassago/src/main/resources/application.yaml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: vassago
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 server:
   port: 8081
 raum:
@@ -16,7 +20,9 @@ vassago:
     initial-size: ${VASSAGO_POOL_INITIAL_SIZE:2}
   jwt:
     transit-key-name: ${VASSAGO_JWT_TRANSIT_KEY_NAME:vassago-jwt}
-    ttl-seconds: ${VASSAGO_JWT_TTL_SECONDS:3600}
+    ttl-seconds: ${VASSAGO_JWT_TTL_SECONDS:300}
+  refresh-token:
+    ttl-seconds: ${VASSAGO_REFRESH_TOKEN_TTL_SECONDS:2592000}
 openbao:
   base-url: ${OPENBAO_BASE_URL:http://localhost:8200}
 mailgun:

--- a/services/vassago/src/test/java/vassago/CreateUserIT.java
+++ b/services/vassago/src/test/java/vassago/CreateUserIT.java
@@ -73,6 +73,12 @@ class CreateUserIT {
 
     @Container
     @SuppressWarnings("resource")
+    static final GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379)
+            .waitingFor(Wait.forListeningPort());
+
+    @Container
+    @SuppressWarnings("resource")
     static final GenericContainer<?> openBao = new GenericContainer<>("openbao/openbao:2.5.2")
             .withNetwork(network)
             .withNetworkAliases("openbao")
@@ -203,7 +209,9 @@ class CreateUserIT {
                     "vassago.service-id=" + vassagoServiceIdStr,
                     "openbao.base-url=http://localhost:%d".formatted(openBao.getMappedPort(8200)),
                     "vassago.jwt.transit-key-name=vassago-jwt",
-                    "vassago.openbao.token=" + vassagoToken
+                    "vassago.openbao.token=" + vassagoToken,
+                    "spring.data.redis.host=localhost",
+                    "spring.data.redis.port=" + redis.getMappedPort(6379)
             );
         }
     }

--- a/services/vassago/src/test/java/vassago/services/UserServiceTest.java
+++ b/services/vassago/src/test/java/vassago/services/UserServiceTest.java
@@ -24,6 +24,7 @@ import vassago.dto.UserResponseDTO;
 import vassago.security.VassagoAuthentication;
 import vassago.security.VassagoRole;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -304,7 +305,8 @@ class UserServiceTest {
     }
 
     private reactor.util.context.Context withCallerUsername(String username, Map<String, List<String>> roles) {
-        VassagoAuthentication auth = new VassagoAuthentication(ORG_ID, username, roles, SERVICE_ID);
+        VassagoAuthentication auth = new VassagoAuthentication(ORG_ID, username, roles, SERVICE_ID,
+                UUID.randomUUID().toString(), Instant.now().plusSeconds(300));
         SecurityContext ctx = mock(SecurityContext.class);
         when(ctx.getAuthentication()).thenReturn(auth);
         return ReactiveSecurityContextHolder.withSecurityContext(Mono.just(ctx));


### PR DESCRIPTION
Allowed for session revocation. To be used in the future upon any anomalies in activity. Current JWT is immediately blacklisted. Any orphaned but still valid JWT is not blacklisted, but should either be expired or close to expiring due to short TTL